### PR TITLE
fix missing \" for terminator output

### DIFF
--- a/output.go
+++ b/output.go
@@ -109,7 +109,7 @@ func printTerminator(colors []color.Color) string {
 		} else if i == len(colors)-1 {
 			output += "#"
 			output += hex.EncodeToString(bytes)
-			output += "\n"
+			output += "\"\n"
 		}
 	}
 	return output


### PR DESCRIPTION
The closing \" is missing for terminator output.
